### PR TITLE
test: align coupon service mocks with reservedAt and full coupon fixture

### DIFF
--- a/src/coupons/coupons.service.spec.ts
+++ b/src/coupons/coupons.service.spec.ts
@@ -350,6 +350,7 @@ describe('CouponsService', () => {
             id: 'uc-001',
             couponId: 'c-001',
             isUsed: false,
+            reservedAt: null,
             coupon: { maxUses: 10, currentUses: 5 },
           }),
           update: jest.fn().mockResolvedValue({
@@ -387,6 +388,7 @@ describe('CouponsService', () => {
             id: 'uc-001',
             couponId: 'c-001',
             isUsed: true,
+            reservedAt: null,
             coupon: { maxUses: 10, currentUses: 5 },
           }),
           update: jest.fn(),
@@ -408,6 +410,7 @@ describe('CouponsService', () => {
             id: 'uc-001',
             couponId: 'c-001',
             isUsed: false,
+            reservedAt: null,
             coupon: { maxUses: 5, currentUses: 5 },
           }),
           update: jest.fn(),
@@ -520,7 +523,13 @@ describe('CouponsService', () => {
         userId: 'user-001',
         isUsed: false,
         reservedAt: null,
-        coupon: { expiresAt: new Date('2027-06-01') },
+        coupon: {
+          expiresAt: new Date('2027-06-01'),
+          category: 'SINGLE_APPOINTMENT',
+          isActive: true,
+          maxUses: null,
+          currentUses: 0,
+        },
       });
       mockUpdate.mockResolvedValue({
         id: 'uc-001',


### PR DESCRIPTION
### Motivation
- Fix failing coupon unit tests where `consumeCouponInTransaction` tried to call `getTime()` on an undefined `reservedAt` in the test fixture.
- Ensure `reserveCoupon` test provides the coupon fields required by `ensureCouponCanBeApplied` so validation no longer rejects the fixture as inactive/invalid.

### Description
- Updated `src/coupons/coupons.service.spec.ts` to include `reservedAt: null` in `userCoupon` mocks used by `consumeCoupon` tests so the reservation-time check can run safely.
- Completed the `reserveCoupon` test fixture's `coupon` object with the required fields (`expiresAt`, `category`, `isActive`, `maxUses`, `currentUses`) so `ensureCouponCanBeApplied` validations pass.
- Only test fixtures were changed; no production code was modified.

### Testing
- Ran Prisma client generation with `DATABASE_URL='postgresql://test:test@localhost:5433/psique_test?schema=public' npm run prisma:generate` to satisfy test environment requirements; generation succeeded.
- Ran the specific coupon tests with `npm run test -- --runInBand src/coupons/coupons.service.spec.ts` and they passed (29 tests).
- Ran the full unit test suite with `npm run test -- --runInBand` and all test suites passed (37 tests total).
- Ran linter with `npm run lint` and autofix; lint completed without blocking errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a385ec7ba38832ba1f9beeb011bc2df)